### PR TITLE
sync-rclone: add DRY_RUN and FORCE_MODE

### DIFF
--- a/sync-rclone
+++ b/sync-rclone
@@ -28,6 +28,10 @@
 # You can set DRY_RUN to 1, to only show commands without running them actually.
 #
 #  $ DRY_RUN=1 SRC_REPO=/tmp/some-dir DST_REPO=gcs:otherproj sync-rclone
+#
+# You can set FORCE_MODE to 1, to be able to overwrite data on the dest repo.
+#
+#  $ FORCE_MODE=1 SRC_REPO=/tmp/some-dir DST_REPO=gcs:otherproj sync-rclone
 
 set -euo pipefail
 
@@ -35,6 +39,7 @@ readonly RCLONE_CONFIGDIR="$HOME/.config/rclone"
 readonly SRC_REPO="${SRC_REPO:-}"
 readonly DST_REPO="${DST_REPO:-}"
 readonly DRY_RUN="${DRY_RUN:-0}"
+readonly FORCE_MODE="${FORCE_MODE:-0}"
 
 if [[ -z "${SRC_REPO}" ]]; then
     echo "ERROR: please set a valid SRC_REPO variable, such as /var/www/origin.release.flatcar-linux.net/alpha."
@@ -48,9 +53,6 @@ fi
 
 readonly GCS_PROJECT_NUMBER="${GCS_PROJECT_NUMBER:-5257126083}"  # NOTE: please fill in a valid project number
 readonly GCS_SERVICE_ACCOUNT_CONFIG="${GCS_SERVICE_ACCOUNT_CONFIG:-${RCLONE_CONFIGDIR}/flatcar.json}"
-
-readonly TIMESTAMP="$(date +%Y%m%d%H%M%S)"
-RCLONE_OPTIONS="--verbose --backup-dir=${DST_REPO}-backup-${TIMESTAMP}"
 
 function pushd {
     command pushd "$@" > /dev/null
@@ -102,6 +104,41 @@ token =
 EOF
 }
 
+# normalize_path returns a valid representation of one of the following paths:
+#  * In case of a normal local path, return its absolute path
+#  * In case of an rclone repo representation, return the original repo string.
+function normalize_path() {
+    local repopath=$1
+
+    if ! [[ "${repopath}" =~ ":" ]]; then
+        repopath=$(realpath -m "${repopath}")
+    fi
+
+    echo "${repopath}"
+}
+
+# repo_exists checks if a repo exists.
+#  * In case of a normal local path, return 1 if a path exists locally.
+#  * In case of an rclone repo representation, return 1 if a remote path
+#    exists on the remote repo.
+function repo_exists() {
+    local ret=0
+    local repopath=$1
+
+    if [[ "$repopath" =~ ":" ]]; then
+        [[ $(rclone ls "${repopath}") ]] && ret=1
+    else
+        repopath=$(realpath -m "${repopath}")
+        [[ -e "${repopath}" ]] && ret=1
+    fi
+
+    echo "${ret}"
+}
+
+readonly TIMESTAMP="$(date +%Y%m%d%H%M%S)"
+readonly DST_REPO_NORM=$(normalize_path "${DST_REPO}")
+RCLONE_OPTIONS="--verbose --backup-dir=${DST_REPO_NORM}-backup-${TIMESTAMP}"
+
 if [[ "${DRY_RUN}" -ne 0 ]]; then
     RCLONE_OPTIONS+=" --dry-run"
 fi
@@ -112,6 +149,14 @@ fi
 
 if [[ ! -f "${RCLONE_CONFIGDIR}/rclone.conf" ]]; then
     gen_rclone_config
+fi
+
+if [[ "${FORCE_MODE}" -eq 0 ]]; then
+    if [[ $(repo_exists "${DST_REPO}") -eq 1 ]]; then
+        echo "${DST_REPO} already exists."
+        echo "If you really know what you are doing, please set FORCE_MODE=1."
+        exit 1
+    fi
 fi
 
 # shellcheck disable=SC2086


### PR DESCRIPTION
When DRY_RUN is set, this script will run rclone with its own option `--dry-run`, which does actually nothing.

```
DRY_RUN=1 SRC_REPO=/tmp/some-dir DST_REPO=gcs:otherproj sync-rclone
```


When sync-rclone is run with FORCE_MODE=1, the script will overwrite the destination even if already exists. Otherwise, the script will fail with an error message.

```
FORCE_MODE=1 SRC_REPO=/tmp/some-dir DST_REPO=gcs:otherproj sync-rclone
```
