### PR TITLE
*: switch GCE bucket name

### DIFF
--- a/fix_vagrant.sh
+++ b/fix_vagrant.sh
@@ -14,7 +14,7 @@ CHANNEL=$1
 VERSION=$2
 readonly GPG="${GPG:-gpg}"
 
-PREFIX="https://storage.googleapis.com/jenkins-flatcar/$CHANNEL/boards/amd64-usr/$VERSION"
+PREFIX="https://storage.googleapis.com/flatcar-jenkins/$CHANNEL/boards/amd64-usr/$VERSION"
 
 for img in flatcar_production_vagrant flatcar_production_vagrant_virtualbox flatcar_production_vagrant_vmware_fusion flatcar_production_vagrant_parallels; do
     wget "$PREFIX/$img".json
@@ -22,7 +22,7 @@ for img in flatcar_production_vagrant flatcar_production_vagrant_virtualbox flat
     wget "$PREFIX/$img".box.DIGESTS
 done
 
-sed -i "s%http://jenkins-flatcar/${CHANNEL}/boards%https://${CHANNEL}.release.flatcar-linux.net%g" *.json
+sed -i "s%http://flatcar-jenkins/${CHANNEL}/boards%https://${CHANNEL}.release.flatcar-linux.net%g" *.json
 
 for f in *.DIGESTS; do
     head -6 $f > $f.tmp

--- a/sync-rclone
+++ b/sync-rclone
@@ -18,7 +18,7 @@
 #  $ SRC_REPO=gcs:otherproj DST_REPO=/tmp/some-dir sync-rclone
 #
 # Note that the remote repo name needs to be a format of REPO_NAME:BUCKET_NAME.
-# such as "gcs:jenkins-flatcar".
+# such as "gcs:flatcar-jenkins".
 #
 # Set custom GCS configs, e.g.:
 #
@@ -47,7 +47,7 @@ if [[ -z "${SRC_REPO}" ]]; then
 fi
 
 if [[ -z "${DST_REPO}" ]]; then
-    echo "ERROR: please set a valid DST_REPO variable, such as gcs:jenkins-flatcar."
+    echo "ERROR: please set a valid DST_REPO variable, such as gcs:flatcar-jenkins."
     exit 1
 fi
 


### PR DESCRIPTION
We are now using Flatcar's own GCE account. Switch to the new bucket.