### PR TITLE
upload_package: fix a bug when calculating file size

### DIFF
--- a/upload_package
+++ b/upload_package
@@ -25,7 +25,7 @@ COREOS_APP_ID="e96281a6-d1af-4bde-9a0a-97b76e56dc57"
 UPDATE_PATH="${DATA_DIR}/flatcar_production_update.gz"
 UPDATE_URL="https://update.release.flatcar-linux.net/amd64-usr/${VERSION}"/
 
-PAYLOAD_SIZE=$(ls -l "${UPDATE_PATH}" | awk '{print $5}')
+PAYLOAD_SIZE=$(stat --format='%s' "${UPDATE_PATH}")
 PAYLOAD_SHA1=$(cat "${UPDATE_PATH}" | openssl dgst -sha1 -binary | base64)
 PAYLOAD_SHA256=$(cat "${UPDATE_PATH}" | openssl dgst -sha256 -binary | base64)
 


### PR DESCRIPTION
Parsing output of ls for getting file size is not an ideal approach, because ls output fields could differ according to systems or software packages. We should use `stat(1)` instead of ls.

This is probably the reason why `wheel` got into the file size field in the coreroller database.

Fixes https://github.com/kinvolk/PROJECT-flatcar-linux/issues/98