### PR TITLE
Thilo/force push like upstream does

### DIFF
--- a/update-repos
+++ b/update-repos
@@ -62,18 +62,20 @@ function update-branches() {
   git push --tags "${ORIGIN}"
 }
 
+
 if [ $# -eq 1 -a -d "${PWD}/$1" ] ; then
     PREFIX="$1"
     echo "Using existing directory $PREFIX"
+    # we're not cleaning up this one since it's user provided
 else
     PREFIX=$(mktemp -d "${PWD}/.update-repos.XXXXXXXXXX")
     echo "Created new directory $PREFIX"
+    # clean up
+    trap '{ export EXT="$?"; rm -rf "${PREFIX}" && exit "${EXT}"; }' EXIT
 fi
 
 cd "${PREFIX}"
 
-# clean up
-#trap '{ export EXT="$?"; rm -rf "${PREFIX}" && exit "${EXT}"; }' EXIT
 
 for repo in "${REPOS[@]}"; do
   [ ! -d "${repo}" ] && git clone "git@github.com:flatcar-linux/${repo}"


### PR DESCRIPTION
Upstream sometimes force-pushes branches, which broke our sync
script in the past since we did not --force.
We're now using the --force, too, to better cope with upstream
changes in an automated way.
