### PR TITLE
fix_vagrant: workaround due to the behavior change in download_url

### DIFF
--- a/fix_vagrant.sh
+++ b/fix_vagrant.sh
@@ -22,7 +22,7 @@ for img in flatcar_production_vagrant flatcar_production_vagrant_virtualbox flat
     wget "$PREFIX/$img".box.DIGESTS
 done
 
-sed -i "s%http://flatcar-jenkins/${CHANNEL}/boards%https://${CHANNEL}.release.flatcar-linux.net%g" *.json
+sed -i "s%https://flatcar-jenkins/${CHANNEL}%https://${CHANNEL}.release.flatcar-linux.net%g" *.json
 
 for f in *.DIGESTS; do
     head -6 $f > $f.tmp


### PR DESCRIPTION
(draft PR. please do not merge)

https://github.com/flatcar-linux/scripts/pull/8 tried to fix the long-running issue with URLs with vagrant json files, but didn't quite fix that. Instead it changed the output URL a little bit.
As a result, `fix_vagrant.sh` cannot fix the vagrant json files any more. So we need to change the sed expression to make it work.

When https://github.com/flatcar-linux/scripts/pull/10 got merged, this workaround will not be needed any more.