### PR TITLE
update-repos: do not push tags to manifest repos

### DIFF
--- a/update-repos
+++ b/update-repos
@@ -38,6 +38,9 @@ REPOS=(
   "update-ssh-keys"
   "update_engine"
   "updateservicectl"
+)
+
+REPOS_MANIFEST=(
   "manifest"
   "manifest-builds"
 )
@@ -49,6 +52,7 @@ REPOS=(
 function update-branches() {
   local UPSTREAM="${1}"
   local ORIGIN="${2}"
+  local PUSH_TAGS="${3}"
   local UPSTREAM_BRANCHES
 
   UPSTREAM_BRANCHES=$(git branch -r | grep "^[ ]*$UPSTREAM" | grep -v HEAD | cut -d/ -f 2-)
@@ -59,7 +63,11 @@ function update-branches() {
 
   # use the --force, Luke!
   git push --all --force "${ORIGIN}"
-  git push --tags "${ORIGIN}"
+
+  # push tags only if PUSH_TAGS is true
+  if [[ ${PUSH_TAGS} == "1" ]] ; then
+    git push --tags "${ORIGIN}"
+  fi
 }
 
 
@@ -83,7 +91,18 @@ for repo in "${REPOS[@]}"; do
   pushd "${repo}"
   git remote add upstream "https://github.com/coreos/${repo}" || true
   git fetch --all
-  update-branches upstream origin
+  update-branches upstream origin 1
+
+  popd
+done
+
+for repo in "${REPOS_MANIFEST[@]}"; do
+  [ ! -d "${repo}" ] && git clone "git@github.com:flatcar-linux/${repo}"
+
+  pushd "${repo}"
+  git remote add upstream "https://github.com/coreos/${repo}" || true
+  git fetch --all
+  update-branches upstream origin 0
 
   popd
 done


### PR DESCRIPTION
We have been pushing upstream tags automatically to manifest repos of flatcar-linux. As a result, we needed to delete remote tags for every release. Actually we don't need to push tags during the `update-repos` phase, because afterwards we will anyway push the tags manually after git-sync has finished.

To solve this issue, split `REPOS` into 2 parts, a normal `REPOS` and `REPOS_MANIFEST`. Deal with different cases with an additional parameter.