### PR TITLE
upload_package: rename coreos_action field to flatcar_action

### DIFF
--- a/upload_package
+++ b/upload_package
@@ -54,7 +54,7 @@ if [ -z "${PACKAGE_ID}" ]; then
             \"size\": \"${PAYLOAD_SIZE}\",
             \"hash\": \"${PAYLOAD_SHA1}\",
             \"application_id\": \"${COREOS_APP_ID}\",
-            \"coreos_action\":
+            \"flatcar_action\":
                 {
                     \"sha256\": \"${PAYLOAD_SHA256}\"
                 }


### PR DESCRIPTION
We've updated Nebraska to have all its variables mention Flatcar instead
of CoreOS so we need to update the upload_package script to get a proper
package in Nebraska. Otherwise it will refuse to send updates to
machines.