### PR TITLE
update-repos: fix unbound variable error

### DIFF
--- a/update-repos
+++ b/update-repos
@@ -56,11 +56,17 @@ function update-systemd-branches() {
   done
 }
 
-if [ $# -eq 1 -a -d "${PWD}/$1" ] ; then
-    PREFIX="$1"
-    echo "Using existing directory $PREFIX"
-    # we're not cleaning up this one since it's user provided
-else
+PREFIX=""
+if [ $# -eq 1 ]; then
+    PREFIXTMP="$1"
+    if [ -d "${PWD}/${PREFIXTMP}" ]; then
+        PREFIX="${PREFIXTMP}"
+        echo "Using existing directory $PREFIX"
+        # we're not cleaning up this one since it's user provided
+    fi
+fi
+
+if [ -z "${PREFIX}" ]; then
     PREFIX=$(mktemp -d "${PWD}/.update-repos.XXXXXXXXXX")
     echo "Created new directory $PREFIX"
     # clean up


### PR DESCRIPTION
Now that we do `set -euo pipefail`, `update-repos` fails like this:

```
./update-repos: line 59: $1: unbound variable
```

To fix that, first store `$PREFIX` to `$PREFIXTMP`, and use it only when the arguments are actually given by user.