### PR TITLE
use a pre-defined variable $ARCH instead of hard-coded amd64-usr

### DIFF
--- a/update-cloudformation-template
+++ b/update-cloudformation-template
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+ARCH=${ARCH:-amd64-usr}
+
 REGIONS=("eu-central-1"
 "ap-northeast-1"
 "ap-northeast-2"
@@ -184,7 +186,7 @@ function generate_templates() {
 mkdir files
 
 for c in alpha beta edge stable; do
-    curl -Lo "$c.json" "https://${c}.release.flatcar-linux.net/amd64-usr/current/flatcar_production_ami_all.json"
+    curl -Lo "$c.json" "https://${c}.release.flatcar-linux.net/${ARCH}/current/flatcar_production_ami_all.json"
     generate_templates hvm $c
     generate_templates pv $c
 done

--- a/upload_package
+++ b/upload_package
@@ -18,13 +18,15 @@ NEBRASKA_URL="$2"
 ORIGIN_SSH_URL="$3"
 VERSION="$4"
 
+ARCH="${ARCH:-amd64-usr}"
+
 COREOS_APP_ID="e96281a6-d1af-4bde-9a0a-97b76e56dc57"
 
 . resty -W "${NEBRASKA_URL}/api" -H "Authorization: Bearer $GITHUB_TOKEN"
 
 UPDATE_PATH="${DATA_DIR}/flatcar_production_update.gz"
 UPDATE_CHECKSUM_PATH="${UPDATE_PATH}.sha256"
-UPDATE_URL="https://update.release.flatcar-linux.net/amd64-usr/${VERSION}"/
+UPDATE_URL="https://update.release.flatcar-linux.net/${ARCH}/${VERSION}"/
 
 PAYLOAD_SIZE=$(stat --format='%s' "${UPDATE_PATH}")
 PAYLOAD_SHA1=$(cat "${UPDATE_PATH}" | openssl dgst -sha1 -binary | base64)
@@ -34,7 +36,7 @@ sha256sum "${UPDATE_PATH}" > "${UPDATE_CHECKSUM_PATH}"
 
 echo "Copying update payload to update server"
 
-SERVER_UPDATE_DIR="/var/www/origin.release.flatcar-linux.net/update/amd64-usr/${VERSION}/"
+SERVER_UPDATE_DIR="/var/www/origin.release.flatcar-linux.net/update/${ARCH}/${VERSION}/"
 ssh "core@${ORIGIN_SSH_URL}" mkdir -p "${SERVER_UPDATE_DIR}"
 scp "${UPDATE_PATH}" "${UPDATE_CHECKSUM_PATH}" "core@${ORIGIN_SSH_URL}:${SERVER_UPDATE_DIR}"
 


### PR DESCRIPTION
With the changes, we can run scripts with a `$ARCH` variable specified by user, like:

```
ARCH=arm64-usr ./upload_package ...
```