### PR TITLE
update-cloudformation-template: Include -arm64 in filename for arm64

### DIFF
--- a/update-cloudformation-template
+++ b/update-cloudformation-template
@@ -193,7 +193,7 @@ function generate_templates() {
     rm "${TMPFILE}"
 }
 
-mkdir files
+mkdir -p files
 
 for c in alpha beta edge stable; do
     rm "$c.json" || true


### PR DESCRIPTION
The published file has the same name for amd64 and arm64.
This clash causes one overwriting the other.