### PR TITLE
update-cloudformation-template: use correct ARCHTAG in URLs

### DIFF
--- a/update-cloudformation-template
+++ b/update-cloudformation-template
@@ -188,7 +188,7 @@ function generate_templates() {
 
     truncate -s-2 ${TMPFILE}
 
-    echo "${TEMPLATE}" | perl -i -0pe "s/###AMIS###/$(cat -- ${TMPFILE})/g" > "files/flatcar-${CHANNEL}-${ARCHTAG}-${TYPE}.template"
+    echo "${TEMPLATE}" | perl -i -0pe "s/###AMIS###/$(cat -- ${TMPFILE})/g" > "files/flatcar-${CHANNEL}${ARCHTAG}-${TYPE}.template"
 
     rm "${TMPFILE}"
 }


### PR DESCRIPTION
Since `$ARCHTAG` is either `""` or `-arm64`, we should not prepend another `-` before the `$ARCHTAG` in the URLs. It will result in `--` in the URLs.

So remove `-`.