### PR TITLE
Add create-manifest helper

### DIFF
--- a/create-manifest
+++ b/create-manifest
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+SCRIPTFOLDER="$(dirname "$(readlink -f "$0")")"
+
+if [ "$VERSION" = "" ] || [ "$SDK_VERSION" = "" ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+  echo "$0:"
+  echo "This script will create a branch in the manifest repository checked out in $SCRIPTFOLDER/manifest and push the branch and tag."
+  echo "The repository is cloned from github.com/flatcar-linux/manifest.git if it does not exist (origin must be flatcar-linux)."
+  echo "Set VERSION and SDK_VERSION as environment variables, e.g., VERSION=2345.3.0 SDK_VERSION=2345.2.0 $0"
+  echo
+  echo "By default the manifest references refs/heads/flatcar-build-VERSION for the repositories scripts, coreos-overlay, and portage-stable"
+  echo "and simply refs/heads/master for the others because their revisions are defined by the CROS_WORKON_COMMIT in the respective ebuild files."
+  echo "Set the environment variables SCRIPTS_REF, OVERLAY_REF, PORTAGE_REF, or DEFAULT_REF to specify any other reference."
+  exit 1
+fi
+
+set -euo pipefail
+
+SCRIPTS_REF="${SCRIPTS_REF-refs/heads/flatcar-build-$VERSION}"
+OVERLAY_REF="${OVERLAY_REF-refs/heads/flatcar-build-$VERSION}"
+PORTAGE_REF="${PORTAGE_REF-refs/heads/flatcar-build-$VERSION}"
+DEFAULT_REF="${DEFAULT_REF-refs/heads/master}"
+
+echo "Running with VERSION=$VERSION SDK_VERSION=$SDK_VERSION"
+echo "SCRIPTS_REF=$SCRIPTS_REF OVERLAY_REF=$OVERLAY_REF PORTAGE_REF=$PORTAGE_REF"
+echo "DEFAULT_REF=$DEFAULT_REF"
+
+cd "$SCRIPTFOLDER/.."
+
+if [ ! -d manifest ]; then
+  git clone git@github.com:flatcar-linux/manifest.git
+fi
+
+cd manifest
+
+if [ "$(git status --porcelain || echo failed)" != "" ]; then
+  echo "Error: Unexpected output of git status:"
+  git status
+  exit 1
+fi
+
+BRANCHNAME="flatcar-build-$VERSION"
+EXISTS=0
+echo "Preparing branch"
+git checkout flatcar-master
+git pull
+git branch "$BRANCHNAME" || EXISTS=1
+git checkout "$BRANCHNAME"
+if [ "$EXISTS" = 1 ]; then
+  echo "Warning: Reusing existing branch $BRANCHNAME, will try to pull."
+  git pull || echo "Warning: Pulling failed. Ignore the above output if the branch just exists locally."
+fi
+echo "Preparing files"
+sed -E -i "s/(FLATCAR_VERSION=)(.*)/\1$VERSION/" version.txt
+sed -E -i "s/(FLATCAR_VERSION_ID=)(.*)/\1$VERSION/" version.txt
+sed -E -i "s/(FLATCAR_SDK_VERSION=)(.*)/\1$SDK_VERSION/" version.txt
+
+echo "Removing old build-*.xml files"
+git rm ./build-*.xml || echo "Warning: Could not delete old files"
+
+FILENAME="build-$(echo "$VERSION" | cut -d '.' -f 1).xml"
+
+export SCRIPTS_REF OVERLAY_REF PORTAGE_REF DEFAULT_REF
+cat "$SCRIPTFOLDER/manifest-template.xml.envsubst" | envsubst '$SCRIPTS_REF $OVERLAY_REF $PORTAGE_REF $DEFAULT_REF' > "$FILENAME"
+# Note: appc-acbuild, appc-spec, rkt, and systemd always stay at refs/heads/master abecause they do not have flatcar-master or flatcar-build-VERSION branches
+
+ln -fs "$FILENAME" default.xml
+cp "$FILENAME" release.xml
+echo "Adding changed files"
+git add "$FILENAME" release.xml default.xml version.txt
+echo "Committing manifest"
+git commit -m "build $VERSION" --author 'Flatcar Buildbot <buildbot@flatcar-linux.org>'
+echo "Pushing branch"
+
+git push --force-with-lease --set-upstream origin "$BRANCHNAME"
+echo "Deleting any existing tags"
+TAG="v$VERSION"
+git tag -d "$TAG" || echo "No local tags deleted"
+git push --delete origin "$TAG" || echo "No remote tags deleted"
+echo "Tagging commit"
+git tag -s "$TAG" -m "$TAG"
+echo "Pushing tag"
+git push origin "$TAG"
+echo "Done"

--- a/manifest-template.xml.envsubst
+++ b/manifest-template.xml.envsubst
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <notice>Your sources have been sync'd successfully.</notice>
+  <remote fetch=".." name="github"/>
+  <remote fetch="ssh://git@github.com" name="private"/>
+  
+  <default remote="github" revision="refs/heads/master" sync-j="4"/>
+  
+  <project groups="minilayout" name="appc/acbuild" path="src/third_party/appc-acbuild" revision="refs/heads/master" upstream="refs/heads/master"/>
+  <project groups="minilayout" name="appc/spec" path="src/third_party/appc-spec" revision="refs/heads/master" upstream="refs/heads/master"/>
+  <project groups="minilayout" name="flatcar-linux/afterburn" path="src/third_party/afterburn" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/baselayout" path="src/third_party/baselayout" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/bootengine" path="src/third_party/bootengine" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/coreos-cloudinit" path="src/third_party/coreos-cloudinit" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/coreos-overlay" path="src/third_party/coreos-overlay" revision="$OVERLAY_REF" upstream="$OVERLAY_REF"/>
+  <project groups="minilayout" name="flatcar-linux/dev-util" path="src/platform/dev" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/docker" path="src/third_party/docker" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/fero" path="src/third_party/fero" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/grub" path="src/third_party/grub" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/ignition" path="src/third_party/ignition" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/init" path="src/third_party/init" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/locksmith" path="src/third_party/locksmith" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/mantle" path="src/third_party/mantle" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/mayday" path="src/third_party/mayday" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/nss-altfiles" path="src/third_party/nss-altfiles" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/portage-stable" path="src/third_party/portage-stable" revision="$PORTAGE_REF" upstream="$PORTAGE_REF"/>
+  <project groups="minilayout" name="flatcar-linux/scripts" path="src/scripts" revision="$SCRIPTS_REF" upstream="$SCRIPTS_REF"/>
+  <project groups="minilayout" name="flatcar-linux/sdnotify-proxy" path="src/third_party/sdnotify-proxy" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/seismograph" path="src/third_party/seismograph" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/shim" path="src/third_party/shim" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/systemd" path="src/third_party/systemd" revision="refs/heads/master" upstream="refs/heads/master"/>
+  <project groups="minilayout" name="flatcar-linux/toolbox" path="src/third_party/toolbox" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/torcx" path="src/third_party/torcx" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/update-ssh-keys" path="src/third_party/update-ssh-keys" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/update_engine" path="src/third_party/update_engine" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/updateservicectl" path="src/third_party/updateservicectl" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="rkt/rkt" path="src/third_party/rkt" revision="refs/heads/master" upstream="refs/heads/master"/>
+</manifest>


### PR DESCRIPTION
Currently the manifest is generated by
git-sync after release branches were created.
If a build fix is needed the manifest needs to
be updated by hand because it uses commit IDs.
Also creating point releases for an old release
is not easy currently because the branch
needs to be copied to add changes and then either
git-sync would separate release branches or the
manifest needs to be created by hand.

Add a script to create manifest entries in
a flexible way, not tied to branch creation.
The manifest uses no commit IDs but branch names
so that no new manifest is needed when build fixes
are done and a Jenkins job restarted.
The script makes point releases easy by copying
the branches via the mirror-repos-branch script,
then applying the changes and creating a new manifest.
References for scripts, coreos-overlay, and portage-stable
can be specified independently so that we can start Jenkins
builds for PRs (this requires a public manifest tag, so in the
future to avoid this we need to tell Jenkins to check out
PR branches itself after the manifest was used).