### PR TITLE
create-manifest: Expand note in manifest-template.xml.envsubst

### DIFF
--- a/manifest-template.xml.envsubst
+++ b/manifest-template.xml.envsubst
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <notice>Your sources have been sync'd successfully.</notice>
+  <notice>Your sources have been sync'd successfully. Note that only the revisions for the coreos-overlay, scripts, and portage-stable repositories are relevant. Revisions for the other repositories are specified in the ebuild files.</notice>
   <remote fetch=".." name="github"/>
   <remote fetch="ssh://git@github.com" name="private"/>
   


### PR DESCRIPTION
Usually the manifest would describe which revision is used for each
repository. This is not exactly the case for Container Linux because
the ebuild files have the last say.
Call this out in the note so that people reading the manifest file
or using it to check repos out are aware of this.