### PR TITLE
cherry-pick-for: Add helper script to pick and push

### DIFF
--- a/cherry-pick-for
+++ b/cherry-pick-for
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ $# -lt 2 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+  echo "Usage: $0 BRANCH COMMITS..."
+  echo "Switches to the given branch, pulls it, cherry-picks all given commits, and pushes the branch"
+  exit 1
+fi
+
+BRANCH="$1"
+COMMITS="${@:2}"
+
+echo "Checking out $BRANCH"
+git checkout "$BRANCH"
+echo "Pulling $BRANCH"
+git pull
+echo "Going to pick $COMMITS"
+for COMMIT in $COMMITS; do
+  echo "Cherry-picking $COMMIT for $BRANCH"
+  git cherry-pick "$COMMIT"
+done
+echo "Successfully picked $COMMITS"
+git push
+echo "Done"


### PR DESCRIPTION
Checking out a branch, ensuring that it is on the latest state,
picking a list of commits, and finally pushing is a error-prone
laborous process which this helper tries to simplify.
Only one branch is accepted and it's easy to rerun the script for
another branch. In case of failure manual resolution is required
and which commits are left can be seen from the log.