### PR TITLE
package-diff: Make comparison of _image_contents.txt useful

### DIFF
--- a/package-diff
+++ b/package-diff
@@ -32,4 +32,12 @@ trap "rm -f \"$A\" \"$B\"" EXIT
 curl --location --silent -S -o "$A" https://storage.googleapis.com/flatcar-jenkins"$MODE_A""$CHANNEL_A"/boards/"$BOARD_A"/"$VERSION_A"/"$FILE"
 curl --location --silent -S -o "$B" https://storage.googleapis.com/flatcar-jenkins"$MODE_B""$CHANNEL_B"/boards/"$BOARD_B"/"$VERSION_B"/"$FILE"
 
+if [ "$FILE" = flatcar_production_image_contents.txt ] || [ "$FILE" = flatcar_developer_container_contents.txt ]; then
+  # Cut date and time noise away
+  sed -i 's/....-..-.. ..:.. //g' "$A" "$B"
+  # Sort by path
+  sort -t / -k 2 --output "$A" "$A"
+  sort -t / -k 2 --output "$B" "$B"
+fi
+
 git diff "$A" "$B"


### PR DESCRIPTION
There was too much noise for the comparison of flatcar_*_contents.txt
being useful because the date and time changes for every file and the
order is not stable.
Ignore the date and time and sort the list by file paths.