### PR TITLE
update-cloudformation-template: Skip missing architectures

### DIFF
--- a/update-cloudformation-template
+++ b/update-cloudformation-template
@@ -177,7 +177,7 @@ mkdir -p files
 
 for c in alpha beta edge stable; do
     rm "$c.json" || true
-    curl -Lo "$c.json" "https://${c}.release.flatcar-linux.net/${ARCH}/current/flatcar_production_ami_all.json" || true
+    curl -s -S -f -Lo "$c.json" "https://${c}.release.flatcar-linux.net/${ARCH}/current/flatcar_production_ami_all.json" || true
     if [ -f "$c.json" ]; then
         generate_templates "$c" "${ARCH}"
         rm "$c.json"


### PR DESCRIPTION
The curl command was creating an output file when a 404 was received
which resulted in the channels without arm64 builds not being skipped.
Add curl flags to error out on 404 without creating the output file.