### PR TITLE
create-manifest: Add maintenance.xml for flatcar-MAJOR branches

### DIFF
--- a/create-manifest
+++ b/create-manifest
@@ -69,8 +69,20 @@ cat "$SCRIPTFOLDER/manifest-template.xml.envsubst" | envsubst '$SCRIPTS_REF $OVE
 
 ln -fs "$FILENAME" default.xml
 cp "$FILENAME" release.xml
+
+MAJOR="${VERSION%%.*}"
+
+echo "Creating maintenance.xml for flatcar-$MAJOR branches"
+
+SCRIPTS_REF="refs/heads/flatcar-$MAJOR"
+OVERLAY_REF="refs/heads/flatcar-$MAJOR"
+PORTAGE_REF="refs/heads/flatcar-$MAJOR"
+
+export SCRIPTS_REF OVERLAY_REF PORTAGE_REF DEFAULT_REF
+cat "$SCRIPTFOLDER/manifest-template.xml.envsubst" | envsubst '$SCRIPTS_REF $OVERLAY_REF $PORTAGE_REF $DEFAULT_REF' > maintenance.xml
+
 echo "Adding changed files"
-git add "$FILENAME" release.xml default.xml version.txt
+git add "$FILENAME" release.xml default.xml version.txt maintenance.xml
 echo "Committing manifest"
 git commit -m "build $VERSION" --author 'Flatcar Buildbot <buildbot@flatcar-linux.org>'
 echo "Pushing branch"


### PR DESCRIPTION
The maintenance branches for a major version should be checked out
easily when creating a local SDK.
Generate a manifest for the maintenance branch of a major version
to be used with
cork create --manifest-branch flatcar-CHANNEL-x.y.z --manifest-name maintenance.xml
See https://github.com/flatcar-linux/docs/pull/102