### PR TITLE
package-diff: Fix documentation for developer builds

### DIFF
--- a/package-diff
+++ b/package-diff
@@ -8,7 +8,7 @@ if [ $# -lt 2 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
   echo "Set CHANNEL_(A|B)=(alpha|beta|edge|developer) to select a build for another channel than stable"
   echo "Set FILE=(flatcar_production_image_contents.txt|flatcar_developer_container_packages.txt|flatcar_developer_container_contents.txt)"
   echo "  to show image contents or developer container packages instead of flatcar_production_image_packages.txt"
-  echo "Set MODE_(A|B)=developer/ to select a developer build"
+  echo "Set MODE_(A|B)=/developer/ to select a developer build"
   exit 1
 fi
 


### PR DESCRIPTION
The default value is a / and to specify a subdirectory the value
must be /developer/ instead of just developer/.

Tested with:
```
CHANNEL_A=alpha CHANNEL_B=developer MODE_B=/developer/ FILE=flatcar_production_image_contents.txt ./package-diff 2513.1.0 2020.07.29+dev-flatcar-master-678
```