### PR TITLE
package-diff: Add FILESONLY mode to only compare the list of files

### DIFF
--- a/package-diff
+++ b/package-diff
@@ -9,6 +9,7 @@ if [ $# -lt 2 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
   echo "Set FILE=(flatcar_production_image_contents.txt|flatcar_developer_container_packages.txt|flatcar_developer_container_contents.txt)"
   echo "  to show image contents or developer container packages instead of flatcar_production_image_packages.txt"
   echo "Set MODE_(A|B)=/developer/ to select a developer build"
+  echo "Set FILESONLY=1 to reduce the flatcar_production_image_contents.txt file to contain only path information"
   exit 1
 fi
 
@@ -23,6 +24,7 @@ MODE_B="${MODE_B-/}"
 FILE="${FILE-flatcar_production_image_packages.txt}"
 VERSION_A="$1"
 VERSION_B="$2"
+FILESONLY="${FILESONLY-0}"
 
 A="$(mktemp "/tmp/$VERSION_A-XXXXXX")"
 B="$(mktemp "/tmp/$VERSION_B-XXXXXX")"
@@ -38,6 +40,12 @@ if [ "$FILE" = flatcar_production_image_contents.txt ] || [ "$FILE" = flatcar_de
   # Sort by path
   sort -t / -k 2 --output "$A" "$A"
   sort -t / -k 2 --output "$B" "$B"
+  if [ "$FILESONLY" = 1 ]; then
+    cut -d . -f 2- "$A" > "$A.cut"
+    mv "$A.cut" "$A"
+    cut -d . -f 2- "$B" > "$B.cut"
+    mv "$B.cut" "$B"
+  fi
 fi
 
 git diff "$A" "$B"


### PR DESCRIPTION
The comparison of the list of files already excludes the timestamp but
still includes the permissions, owner, and size by default where especially
the size can be noisy.
Add a mode to cut everything except the path away:
FILESONLY=1 FILE=flatcar_production_image_contents.txt ./package-diff 2512.5.0 2605.5.0