### PR TITLE
cherry-pick-for: Cut away merging person metadata

### DIFF
--- a/cherry-pick-for
+++ b/cherry-pick-for
@@ -43,7 +43,7 @@ if [ "${COMMITS:0:4}" = http ]; then
     META="$(curl -s -S -f -L "$URL" | grep '<title>.*GitHub</title>')"
     PR_MSG1="Merge$(echo "$META" | cut -d '·' -f 2 | tr '[:upper:]' '[:lower:]')"
     PR_MSG2="from$(echo "$META" | cut -d '·' -f 3)"
-    PR_TITLE="$(echo "$META" | cut -d '·' -f 1 | cut -d '>' -f 2-)"
+    PR_TITLE="$(echo "$META" | cut -d '·' -f 1 | cut -d '>' -f 2- | rev | cut -d ' ' -f 4- | rev)"
     COMMIT_MSG="$PR_MSG1$PR_MSG2
 
 $PR_TITLE"


### PR DESCRIPTION
The commit message included the "by MERGER" suffix that GitHub adds to
the HTML page title. This caused that the merge commits had a longer
message body.
Cut away the metadata about the merging person. The only difference
remaining is that the repository name is used instead of the original
branch name. Still the noise in coreos-overlay-diff is slightly reduced
by having the same PR title printed.