### PR TITLE
create-manifest: fetch repo if its local repo already exists

### DIFF
--- a/create-manifest
+++ b/create-manifest
@@ -30,11 +30,15 @@ echo "DEFAULT_REF=$DEFAULT_REF"
 
 cd "$SCRIPTFOLDER/.."
 
-if [ ! -d manifest ]; then
-  git clone git@github.com:flatcar-linux/manifest.git
+MANIFESTFOLDER="manifest"
+
+if [ -d "${MANIFESTFOLDER}" ]; then
+  git -C "${MANIFESTFOLDER}" fetch --prune origin
+else
+  git clone git@github.com:flatcar-linux/manifest.git "${MANIFESTFOLDER}"
 fi
 
-cd manifest
+cd "${MANIFESTFOLDER}"
 
 if [ "$(git status --porcelain || echo failed)" != "" ]; then
   echo "Error: Unexpected output of git status:"


### PR DESCRIPTION
If the `manifest` repo already exists as a local directory, we should at least fetch from origin with an option `--prune`, to make sure that the local refs match with remote refs.

Otherwise, it might end up with strange cases, where a branch exists only locally, while its remote branch has been already removed.
As a result, `git push` does not work at all, as git think the branch is already up-to-date.