### PR TITLE
tag-release|create-manifest: Detect special branch prefix for LTS

### DIFF
--- a/create-manifest
+++ b/create-manifest
@@ -76,11 +76,16 @@ cp "$FILENAME" release.xml
 
 MAJOR="${VERSION%%.*}"
 
-echo "Creating maintenance.xml for flatcar-$MAJOR branches"
+MAINT="flatcar"
+if [ "$CHANNEL" = lts ]; then
+  MAINT="flatcar-lts"
+fi
 
-SCRIPTS_REF="refs/heads/flatcar-$MAJOR"
-OVERLAY_REF="refs/heads/flatcar-$MAJOR"
-PORTAGE_REF="refs/heads/flatcar-$MAJOR"
+echo "Creating maintenance.xml for $MAINT-$MAJOR branches"
+
+SCRIPTS_REF="refs/heads/$MAINT-$MAJOR"
+OVERLAY_REF="refs/heads/$MAINT-$MAJOR"
+PORTAGE_REF="refs/heads/$MAINT-$MAJOR"
 
 export SCRIPTS_REF OVERLAY_REF PORTAGE_REF DEFAULT_REF
 cat "$SCRIPTFOLDER/manifest-template.xml.envsubst" | envsubst '$SCRIPTS_REF $OVERLAY_REF $PORTAGE_REF $DEFAULT_REF' > maintenance.xml

--- a/tag-release
+++ b/tag-release
@@ -21,9 +21,14 @@ set -euo pipefail
 
 MAJOR="${VERSION%%.*}"
 
-SCRIPTS_REF="${SCRIPTS_REF-origin/flatcar-$MAJOR}"
-OVERLAY_REF="${OVERLAY_REF-origin/flatcar-$MAJOR}"
-PORTAGE_REF="${PORTAGE_REF-origin/flatcar-$MAJOR}"
+MAINT="flatcar"
+if [ "$CHANNEL" = lts ]; then
+  MAINT="flatcar-lts"
+fi
+
+SCRIPTS_REF="${SCRIPTS_REF-origin/$MAINT-$MAJOR}"
+OVERLAY_REF="${OVERLAY_REF-origin/$MAINT-$MAJOR}"
+PORTAGE_REF="${PORTAGE_REF-origin/$MAINT-$MAJOR}"
 
 echo "Running with CHANNEL=$CHANNEL VERSION=$VERSION MAJOR=$MAJOR"
 echo "SCRIPTS_REF=$SCRIPTS_REF OVERLAY_REF=$OVERLAY_REF PORTAGE_REF=$PORTAGE_REF"


### PR DESCRIPTION
The LTS releases are done from branches starting with flatcar-lts
instead of flatcar. When the default arguments are used, the normal
branch was taken for the LTS channel.
Detect the LTS channel and use the special branch prefix.

# How to use

```
VERSION=2605.7.1 CHANNEL=lts  ./tag-release
VERSION=2605.7.1 CHANNEL=lts  SDK_VERSION=2605.0.0 ./create-manifest
```

# Testing done

The above
