### PR TITLE
Use new repo locations

### DIFF
--- a/coreos-overlay-diff.py
+++ b/coreos-overlay-diff.py
@@ -39,7 +39,7 @@ elif args.diff_style == "delta":
 
 warnings = []
 
-repo_map = {"coreos-init": "init", "cros-devutils": "dev-util", "gmerge": "dev-util",
+repo_map = {"coreos-init": "init", "cros-devutils": "flatcar-dev-util", "gmerge": "flatcar-dev-util",
             "fero-client": "fero", "actool": "spec"}
 
 
@@ -78,9 +78,9 @@ def pull_requests_for_merge_commits(src="src", dst="dst", repo="repo"):
     filtered = [line for line in merge_commits.split("\n") if "Merge pull request" in line and line.count("#") >= 2]
     # Won't panic because we ensured above that two # characters exist
     pr_and_titles = [(line.split("#")[1].split(" ")[0], "#".join(line.split("#")[2:])) for line in filtered]
-    # TODO: find the correct upstream GitHub organization (from branch?) if it isn't flatcar-linux but systemd or coreos
+    # TODO: find the correct upstream GitHub organization (from branch?) if it isn't kinvolk but systemd or coreos
     # Ignores PRs that tell that they only change the .github folder by having a title starting with ".github"
-    links = [title + ": https://github.com/flatcar-linux/" + repo + "/pull/" + pr for (pr, title) in pr_and_titles if not title.startswith(".github")]
+    links = [title + ": https://github.com/kinvolk/" + repo + "/pull/" + pr for (pr, title) in pr_and_titles if not title.startswith(".github")]
     return "\n".join(links)
 
 def display_difference(from_theirs, to_ours, name, recurse=False):
@@ -171,7 +171,7 @@ def display_difference(from_theirs, to_ours, name, recurse=False):
                         os.chdir(base_folder + repo)
                     except FileNotFoundError:
                         print("Failed to enter repo directory for \"" + repo + "\", trying to clone it")
-                        git.clone("git@github.com:flatcar-linux/" + repo + ".git")
+                        git.clone("git@github.com:kinvolk/" + repo + ".git")
                         os.chdir(repo)
                     try:
                         git.fetch("github")

--- a/create-manifest
+++ b/create-manifest
@@ -5,13 +5,13 @@ SCRIPTFOLDER="$(dirname "$(readlink -f "$0")")"
 if [ "$VERSION" = "" ] || [ "$SDK_VERSION" = "" ] || [ "$CHANNEL" = "" ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
   echo "$0:"
   echo "This script will create a branch in the manifest repository checked out in $SCRIPTFOLDER/../manifest and push the branch and tag."
-  echo "The repository is cloned from github.com/flatcar-linux/manifest.git if it does not exist (origin in an existing repository must point there"
+  echo "The repository is cloned from github.com/kinvolk/manifest.git if it does not exist (origin in an existing repository must point there"
   echo "or pushing fails or does some unwanted action)."
   echo "Set VERSION, SDK_VERSION, and CHANNEL as environment variables, e.g., VERSION=2345.3.0 SDK_VERSION=2345.2.0 CHANNEL=stable $0"
   echo
-  echo "It creates tags only for the manifest repository. Tags for the repositories scripts, coreos-overlay, and portage-stable should be"
+  echo "It creates tags only for the manifest repository. Tags for the repositories flatcar-scripts, coreos-overlay, and portage-stable should be"
   echo "created first with ./tag-release (which can be rerun on build failures to introduce fixes without changing the manifest)."
-  echo "By default the manifest references refs/tags/CHANNEL-VERSION for the repositories scripts, coreos-overlay, and portage-stable"
+  echo "By default the manifest references refs/tags/CHANNEL-VERSION for the repositories flatcar-scripts, coreos-overlay, and portage-stable"
   echo "and simply refs/heads/master for the others because their revisions are defined by the CROS_WORKON_COMMIT in the respective ebuild files."
   echo "Set the environment variables SCRIPTS_REF, OVERLAY_REF, PORTAGE_REF, or DEFAULT_REF to specify any other reference."
   exit 1
@@ -35,7 +35,7 @@ MANIFESTFOLDER="manifest"
 if [ -d "${MANIFESTFOLDER}" ]; then
   git -C "${MANIFESTFOLDER}" fetch --prune origin
 else
-  git clone git@github.com:flatcar-linux/manifest.git "${MANIFESTFOLDER}"
+  git clone git@github.com:kinvolk/manifest.git "${MANIFESTFOLDER}"
 fi
 
 cd "${MANIFESTFOLDER}"

--- a/mirror-repos-branch
+++ b/mirror-repos-branch
@@ -30,7 +30,7 @@ fi
 . ./lib/common.sh
 
 if [ "${ALL_REPOS}" = "0" ]; then
-  FLATCAR_REPOS=("coreos-overlay" "portage-stable" "scripts")
+  FLATCAR_REPOS=("coreos-overlay" "portage-stable" "flatcar-scripts")
 fi
 
 REPOS_DIR=$(mktemp -d "${PWD}/.mirror-repos.XXXXXXXXXX")
@@ -48,7 +48,7 @@ for repo in "${FLATCAR_REPOS[@]}"; do
     continue
   fi
 
-  HEAD_URL="git@github.com:flatcar-linux/${repo}"
+  HEAD_URL="git@github.com:kinvolk/${repo}"
 
   [ ! -d "${repo}" ] && git clone "${HEAD_URL}"
 

--- a/tag-release
+++ b/tag-release
@@ -4,9 +4,9 @@ SCRIPTFOLDER="$(dirname "$(readlink -f "$0")")"
 
 if [ "$VERSION" = "" ] || [ "$CHANNEL" = "" ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
   echo "$0:"
-  echo "This script will create and push release tags in the repositories scripts, coreos-overlay, and portage-stable"
-  echo "checked out in $SCRIPTFOLDER/../(scripts|coreos-overlay|portage-stable). The repositories will be cloned from"
-  echo "github.com/flatcar-linux/(scripts|coreos-overlay|portage-stable).git if they do not exist (origin in an existing"
+  echo "This script will create and push release tags in the repositories flatcar-scripts, coreos-overlay, and portage-stable"
+  echo "checked out in $SCRIPTFOLDER/../(flatcar-scripts|coreos-overlay|portage-stable). The repositories will be cloned from"
+  echo "github.com/kinvolk/(flatcar-scripts|coreos-overlay|portage-stable).git if they do not exist (origin in an existing"
   echo "repository must point there or pushing fails or does some unwanted action)."
   echo "Set VERSION and CHANNEL as environment variables, e.g., VERSION=2345.3.0 CHANNEL=stable $0"
   echo
@@ -33,13 +33,13 @@ PORTAGE_REF="${PORTAGE_REF-origin/$MAINT-$MAJOR}"
 echo "Running with CHANNEL=$CHANNEL VERSION=$VERSION MAJOR=$MAJOR"
 echo "SCRIPTS_REF=$SCRIPTS_REF OVERLAY_REF=$OVERLAY_REF PORTAGE_REF=$PORTAGE_REF"
 
-REPOS="scripts coreos-overlay portage-stable"
+REPOS="flatcar-scripts coreos-overlay portage-stable"
 
 for REPO in ${REPOS}; do
   echo "Preparing ${REPO}"
   cd "$SCRIPTFOLDER/.."
   if [ ! -d "${REPO}" ]; then
-    git clone "git@github.com:flatcar-linux/${REPO}.git"
+    git clone "git@github.com:kinvolk/${REPO}.git"
   fi
   cd "${REPO}"
   git fetch origin
@@ -47,7 +47,7 @@ for REPO in ${REPOS}; do
   echo "Deleting tag ${TAG} if it exists in ${REPO}"
   git tag -d "$TAG" || echo "No local tags deleted"
   git push --delete origin "$TAG" || echo "No remote tags deleted"
-  [ "${REPO}" = "scripts" ] && REF="${SCRIPTS_REF}"
+  [ "${REPO}" = "flatcar-scripts" ] && REF="${SCRIPTS_REF}"
   [ "${REPO}" = "coreos-overlay" ] && REF="${OVERLAY_REF}"
   [ "${REPO}" = "portage-stable" ] && REF="${PORTAGE_REF}"
   echo "Tagging ${REF} as ${TAG}"


### PR DESCRIPTION
The repositories have been unified under the Kinvolk GitHub Org.
Use the new location.


# How to use

Rename your existing `scripts` development folder if you don't want a new `flatcar-scripts` folder to be cloned automatically when running `tag-release`.

# Testing done

Not everything but used it in the last releases