### PR TITLE
Drop systemd from FLATCAR_REPOS

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -30,7 +30,6 @@ export FLATCAR_REPOS=(
   "seismograph"
   "shim"
   "sysroot-wrappers"
-  "systemd"
   "toolbox"
   "torcx"
   "update-ssh-keys"


### PR DESCRIPTION
We don't use systemd git repo in our workflow anymore, and it was also dropped from manifest too.
