### PR TITLE
sync-rclone: remove outdated curl --progress option

### DIFF
--- a/sync-rclone
+++ b/sync-rclone
@@ -66,7 +66,7 @@ function install_rclone {
     local RCLONE_DESTDIR="/opt/bin"
 
     pushd /tmp
-    curl -L --progress https://downloads.rclone.org/rclone-current-linux-amd64.zip -o /tmp/rclone-current-linux-amd64.zip
+    curl -L https://downloads.rclone.org/rclone-current-linux-amd64.zip -o /tmp/rclone-current-linux-amd64.zip
     unzip rclone-current-linux-amd64.zip
 
     pushd rclone-*-linux-amd64


### PR DESCRIPTION
The --progress option is reported as "ambiguous" and we can do without.
