### PR TITLE
package-diff: add rough /boot and /usr file size comparison

### DIFF
--- a/package-diff
+++ b/package-diff
@@ -11,6 +11,7 @@ if [ $# -lt 2 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
   echo "Set MODE_(A|B)=/developer/ to select a developer build"
   echo "Set FILESONLY=1 to reduce the flatcar_production_image_contents.txt file to contain only path information"
   echo "Set CUTKERNEL=1 to reduce the flatcar_production_image_contents.txt file to contain no kernel version in paths but just 'a.b.c-flatcar'"
+  echo "Alternatively, set CALCSIZE=1 to sum up the file sizes from flatcar_production_image_contents.txt (/boot and /usr, excluding symlinks and directories)"
   exit 1
 fi
 
@@ -27,6 +28,7 @@ VERSION_A="$1"
 VERSION_B="$2"
 FILESONLY="${FILESONLY-0}"
 CUTKERNEL="${CUTKERNEL-0}"
+CALCSIZE="${CALCSIZE-0}"
 
 A="$(mktemp "/tmp/$VERSION_A-XXXXXX")"
 B="$(mktemp "/tmp/$VERSION_B-XXXXXX")"
@@ -50,6 +52,12 @@ if [ "$FILE" = flatcar_production_image_contents.txt ] || [ "$FILE" = flatcar_de
   fi
   if [ "$CUTKERNEL" = 1 ]; then
     sed -i -E 's#[0-9]+\.[0-9]+\.[0-9]+-flatcar#a.b.c-flatcar#g' "$A" "$B"
+  fi
+  if [ "$CALCSIZE" = 1 ]; then
+    A_SUM=$(grep -v '^d' "$A" | grep -v '^l' | rev | cut -d ' ' -f 2 | rev | paste -sd+ - | bc)
+    echo "$(echo "${A_SUM}/1024/1024" | bc) MiB" > "$A"
+    B_SUM=$(grep -v '^d' "$B" | grep -v '^l' | rev | cut -d ' ' -f 2 | rev | paste -sd+ - | bc)
+    echo "$(echo "${B_SUM}/1024/1024" | bc) MiB" > "$B"
   fi
 fi
 


### PR DESCRIPTION
We need to monitor how full the filesystems get because they have a
fixed maximum size.

Add a mode to simply sum up the file sizes of both /boot and /usr to
get a rough number on how much the file sizes increase when comparing
to images.

## How to use/testing done

```
CALCSIZE=1 FILE=flatcar_production_image_contents.txt CHANNEL_B=alpha ./package-diff 2765.2.3 2905.0.0
diff --git a/tmp/2765.2.3-DIMDJt b/tmp/2905.0.0-0nYzLy
index accd082..8f0ace8 100644
--- a/tmp/2765.2.3-DIMDJt
+++ b/tmp/2905.0.0-0nYzLy
@@ -1 +1 @@
-1258 MiB
+1156 MiB
```