### PR TITLE
Prepare github org rename

### DIFF
--- a/devstats
+++ b/devstats
@@ -30,20 +30,20 @@ if [ "${2-}" != "" ]; then
   TO="${2}"
 fi
 
-# Excluded: flatcar-linux/ignition flatcar-linux/afterburn flatcar-linux/ign-converter flatcar-linux/grub
+# Excluded: flatcar/ignition flatcar/afterburn flatcar/ign-converter flatcar/grub
 # (because they are upstream projects)
-REPOS=(flatcar-linux/scripts flatcar-linux/coreos-overlay flatcar-linux/portage-stable flatcar-linux/flatcar-docs
-       flatcar-linux/init flatcar-linux/flatcar-linux-update-operator flatcar-linux/flatcar-build-scripts
-       flatcar-linux/mantle flatcar-linux/update-ssh-keys flatcar-linux/container-linux-config-transpiler
-       flatcar-linux/locksmith flatcar-linux/bootengine flatcar-linux/baselayout
-       flatcar-linux/flatcar-packer-qemu flatcar-linux/sysext-bakery
-       flatcar-linux/flatcar-dev-util flatcar-linux/torcx flatcar-linux/update_engine flatcar-linux/flatcar-terraform
-       flatcar-linux/coreos-cloudinit flatcar-linux/fleetlock flatcar-linux/toolbox flatcar-linux/seismograph
-       flatcar-linux/updateservicectl flatcar-linux/mayday
-       flatcar-linux/nss-altfiles flatcar-linux/sysroot-wrappers flatcar-linux/shim
-       flatcar-linux/fero flatcar-linux/efunctions flatcar-linux/chromite
-       flatcar-linux/flatcar-release-mirror flatcar-linux/sdnotify-proxy
-       flatcar-linux/flog kinvolk/nebraska)
+REPOS=(flatcar/scripts flatcar/coreos-overlay flatcar/portage-stable flatcar/flatcar-docs
+       flatcar/init flatcar/flatcar-update-operator flatcar/flatcar-build-scripts
+       flatcar/mantle flatcar/update-ssh-keys flatcar/container-linux-config-transpiler
+       flatcar/locksmith flatcar/bootengine flatcar/baselayout
+       flatcar/flatcar-packer-qemu flatcar/sysext-bakery
+       flatcar/flatcar-dev-util flatcar/torcx flatcar/update_engine flatcar/flatcar-terraform
+       flatcar/coreos-cloudinit flatcar/fleetlock flatcar/toolbox flatcar/seismograph
+       flatcar/updateservicectl flatcar/mayday
+       flatcar/nss-altfiles flatcar/sysroot-wrappers flatcar/shim
+       flatcar/fero flatcar/efunctions flatcar/chromite
+       flatcar/flatcar-release-mirror flatcar/sdnotify-proxy
+       flatcar/flog kinvolk/nebraska)
 
 OUTPUT=""
 
@@ -133,7 +133,7 @@ PATTERN="(microsoft|kinvolk)"
 
 echo
 echo "Commits from ${FROM} to ${TO} in"
-echo "  ${REPOS[*]}" | sed 's#flatcar-linux/##g' | fmt
+echo "  ${REPOS[*]}" | sed 's#flatcar/##g' | fmt
 echo
 echo "Kinvolk/Microsoft:"
 echo "${STATS}" | grep -P "${PATTERN}"

--- a/mirror-repos-branch
+++ b/mirror-repos-branch
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Mirroring a specific branch from the flatcar-linux remote repos.
+# Mirroring a specific branch from the flatcar remote repos.
 # Run it like:
 #
 #  ./mirror-repos-branch build-2010.0.1 flatcar-build-2010.0.1
@@ -48,7 +48,7 @@ for repo in "${FLATCAR_REPOS[@]}"; do
     continue
   fi
 
-  HEAD_URL="git@github.com:flatcar-linux/${repo}"
+  HEAD_URL="git@github.com:flatcar/${repo}"
 
   [ ! -d "${repo}" ] && git clone --recurse-submodules "${HEAD_URL}"
 

--- a/tag-release
+++ b/tag-release
@@ -6,7 +6,7 @@ if [ "${SDK_VERSION}" = "" ] || [ "$VERSION" = "" ] || [ "$CHANNEL" = "" ] || [ 
   echo "$0:"
   echo "This script will create and push release tags in the repositories scripts, coreos-overlay, and portage-stable"
   echo "checked out in $SCRIPTFOLDER/../(scripts|coreos-overlay|portage-stable). The repositories will be cloned from"
-  echo "github.com/flatcar-linux/(scripts|coreos-overlay|portage-stable).git if they do not exist (origin in an existing"
+  echo "github.com/flatcar/(scripts|coreos-overlay|portage-stable).git if they do not exist (origin in an existing"
   echo "repository must point there or pushing fails or does some unwanted action)."
   echo "Set VERSION, SDK_VERSION, and CHANNEL as environment variables, e.g., VERSION=2345.3.0 SDK_VERSION=2345.0.0 CHANNEL=stable $0"
   echo
@@ -40,7 +40,7 @@ for REPO in ${REPOS}; do
   echo "Preparing ${REPO}"
   cd "$SCRIPTFOLDER/.."
   if [ ! -d "${REPO}" ]; then
-    git clone --recurse-submodules "git@github.com:flatcar-linux/${REPO}.git"
+    git clone --recurse-submodules "git@github.com:flatcar/${REPO}.git"
   fi
   cd "${REPO}"
   git fetch origin


### PR DESCRIPTION
The "flatcar-linux" org will be renamed to "flatcar". For renames, there are no redirections in place and we have to update all links.


## How to use

Merge when org rename is done.

(The old pipeline manifest creation is left as is, we can delete it in the future but let's keep it around until the first release with the new pipeline is done)