### PR TITLE
sync-gentoo-glsa: add amend mode, detect metadata/glsa

### DIFF
--- a/sync-with-gentoo
+++ b/sync-with-gentoo
@@ -31,6 +31,7 @@ declare -a GLOBAL_extra_git_commit_options=()
 GLOBAL_single_commit=''
 declare -a GLOBAL_obsolete_packages=()
 GLOBAL_gentoo_repo="${GENTOO_REPO:-../gentoo}"
+GLOBAL_amend_mode=''
 
 while true; do
     case "${1}" in
@@ -39,6 +40,7 @@ while true; do
             echo 'OPTIONS:'
             echo '  --help|-h: Print this help and quit'
             echo '  --message|-m: Additional messages for commits, will be passed to git commit --message, can be specified many times'
+            echo '  --amend-mode|-a: Updates commit message to use the new used hash sum of the commit.'
             echo '  --single-commit: Lump all the changes under a single commit'
             echo
             echo 'ENVIRONMENT VARIABLES:'
@@ -49,6 +51,10 @@ while true; do
         '--message'|'-m')
             GLOBAL_extra_git_commit_options+=(--message "${2}")
             shift 2
+            ;;
+        '--amend-mode'|'-a')
+            GLOBAL_amend_mode=1
+            shift
             ;;
         '--single-commit'|'-s')
             GLOBAL_single_commit='x'
@@ -127,14 +133,32 @@ maybe_commit_with_gentoo_sha() {
     local sync="${3}"
 
     if [[ -z "${GLOBAL_single_commit}" ]]; then
+        local do_amend=''
+        local do_add=''
+        if [[ -n "${GLOBAL_amend_mode}" ]]; then
+            local subject
+
+            subject="$(git log -1 --pretty=format:%s)"
+            if [[ "${subject}" = "${name}:"* ]]; then
+                do_amend=1
+            fi
+            if [[ "${subject}" = *'Add from Gentoo'* ]]; then
+                do_add=1
+            fi
+        fi
         local commit=''
         local commit_msg=''
+        local amend_args=()
+        if [[ -n "${do_amend}" ]]; then
+            amend_args+=(--amend --no-edit)
+        fi
         commit=$(git -C "${GLOBAL_gentoo_repo}" log --pretty=oneline -1 -- "${path}" | cut -f1 -d' ')
         commit_msg="${name}: Add from Gentoo"
-        if [[ -n "${sync}" ]]; then
+        if [[ -n "${sync}" ]] && [[ -z "${do_add}" ]]; then
             commit_msg="${name}: Sync with Gentoo"
         fi
         if ! commit_and_show \
+             "${amend_args[@]}" \
              --message "${commit_msg}" \
              --message "It's from Gentoo commit ${commit}."; then
             echo "no changes in ${path}"

--- a/sync-with-gentoo
+++ b/sync-with-gentoo
@@ -206,6 +206,9 @@ for cpn; do
         eclass/*.eclass)
             path_sync "${cpn}" "${cpn%.eclass}"
             ;;
+        metadata/glsa)
+            path_sync "${cpn}" "${cpn}"
+            ;;
         metadata)
             fail "metadata directory can't be synced"
             ;;


### PR DESCRIPTION
Add amend mode that updates the commit message to use the new used hash sum of the commit. (by @krnowak )

Detect `metadata/glsa` to sync only the metadata/glsa directory. It is needed for a montly Github Actions for syncing GLSA metadata.