### PR TITLE
devstats: Show commit count as summary

### DIFF
--- a/devstats
+++ b/devstats
@@ -141,3 +141,4 @@ echo
 echo "Non-Kinvolk/Microsoft:"
 echo "${STATS}" | grep -v -P "${PATTERN}"
 echo
+echo "Total commits: $(($(echo "${COUNTER[@]}" | tr -s '[:blank:]' '+')))"


### PR DESCRIPTION
Show the sum of all commit counts as summary.

## Testing done

`SKIP_FETCH=1 DEBUG=1 ./devstats` and `SKIP_FETCH=1 ./devstats 2022-01-01`