### PR TITLE
size-change-report: Silence the sort

### DIFF
--- a/size-change-report.sh
+++ b/size-change-report.sh
@@ -232,7 +232,7 @@ function xgit {
 }
 
 function xsort {
-    sort "${@}" || :
+    sort "${@}" 2>/dev/null || :
 }
 
 function file_lineno {


### PR DESCRIPTION
The `sort | head` pipeline results in sort complaining about a broken stdout pipe. This kinda makes sense, because sort wants to write all the sorted results, while head just reads first 10 lines and closes its input end of the pipe. For some reason I can't reproduce it locally, but it's annoying to see those messages in the image differences job. Since we already ignore errors from sort, send its complaints to /dev/null too.
