### PR TITLE
devstats: Add one more entry to match GitHub usernames

### DIFF
--- a/devstats
+++ b/devstats
@@ -111,6 +111,9 @@ for REPO in "${REPOS[@]}"; do
       if [ "${AUTHOR}" = "Iago López Galeiras" ]; then
         AUTHOR="Iago Lopez Galeiras"
       fi
+      if [ "${AUTHOR}" = "krnowak" ]; then
+        AUTHOR="Krzesimir Nowak"
+      fi
       PREV_COUNT="${COUNTER["${AUTHOR}"]-0}"
       COUNTER["${AUTHOR}"]=$((COUNT + PREV_COUNT))
       PREV_EMAILS="${EMAILS["${AUTHOR}"]-}"


### PR DESCRIPTION
The GitHub username is sometimes directly used if an action is done through the web UI or similar, depending on the settings. For these cases we can link the commits to the existing entries to prevent duplicates.
