### PR TITLE
upload_package: Report failed registrations as failures

### DIFF
--- a/upload_package
+++ b/upload_package
@@ -77,7 +77,7 @@ fi
 echo "Uploading update payload"
 
 if [ -z "${PACKAGE_ID}" ]; then
-    if ! PACKAGE_ID=$(POST /apps/"${COREOS_APP_ID}"/packages " \
+    if ! PACKAGE_JSON=$(POST /apps/"${COREOS_APP_ID}"/packages " \
         {
             \"application_id\": \"${COREOS_APP_ID}\",
             \"arch\": ${ARCH_ID},
@@ -94,11 +94,12 @@ if [ -z "${PACKAGE_ID}" ]; then
                     \"sha256\": \"${PAYLOAD_SHA256}\"
                 }
         }
-        " 2>&1 | jq .id); then
+        " 2>&1); then
 		echo "Failed to update metadata on Nebraska."
 		echo "Please make sure that you have configured a valid GITHUB_TOKEN."
 		exit 1
 	fi
+        PACKAGE_ID=$(echo "${PACKAGE_JSON}" | jq .id)
 else
     echo "Payload with version ${VERSION} already present. Skipping upload..."
     exit 1

--- a/upload_package
+++ b/upload_package
@@ -18,6 +18,11 @@ NEBRASKA_URL="$2"
 ORIGIN_SSH_URL="$3"
 VERSION="$4"
 
+# Used for debugging/testing of the staging server:
+NOUPLOAD="${NOUPLOAD-}"
+# touch /tmp/flatcar_production_update.gz
+# NOUPLOAD=1 ./upload_package /tmp https://staging.updateservice.flatcar-linux.net notused 9.9.9
+
 ARCH="${ARCH:-amd64-usr}"
 echo "Environment variable ARCH is specified as ${ARCH}"
 
@@ -54,8 +59,12 @@ sha256sum "${UPDATE_PATH}" > "${UPDATE_CHECKSUM_PATH}"
 echo "Copying update payload to update server"
 
 SERVER_UPDATE_DIR="/var/www/origin.release.flatcar-linux.net/update/${ARCH}/${VERSION}/"
-ssh "core@${ORIGIN_SSH_URL}" mkdir -p "${SERVER_UPDATE_DIR}"
-scp "${UPDATE_PATH}" "${UPDATE_CHECKSUM_PATH}" "core@${ORIGIN_SSH_URL}:${SERVER_UPDATE_DIR}"
+if [ "${NOUPLOAD}" = "" ]; then
+  ssh "core@${ORIGIN_SSH_URL}" mkdir -p "${SERVER_UPDATE_DIR}"
+  scp "${UPDATE_PATH}" "${UPDATE_CHECKSUM_PATH}" "core@${ORIGIN_SSH_URL}:${SERVER_UPDATE_DIR}"
+else
+  echo "NOUPLOAD set, skipping upload to origin server"
+fi
 
 # Nebraska's arch enum values:
 # https://github.com/kinvolk/nebraska/blob/953a1e672f42dea4530161a31756db239e0bb8aa/pkg/api/arch.go#L9


### PR DESCRIPTION
- upload_package: Report failed registrations as failures

    The script doesn't run with pipefail, thus the POST failing was ignored 
as long as jq did not give an error code.                               
Split the line into two to make sure we catch errors without requiring  
set -o pipefail. 

- upload_package: Allow to skip the upload to Origin
    
    For testing we don't want to upload the file because we might not even
    have a vaild file to test.
    Allow to skip the upload, making it possible to run as:
      touch /tmp/flatcar_production_update.gz
      NOUPLOAD=1 ./upload_package /tmp https://staging.updateservice.flatcar-linux.net notused 9.9.9


## How to use


## Testing done

Tested on staging