### PR TITLE
show-fixed-kernel-cves: fix type error when converting cve list

### DIFF
--- a/show-fixed-kernel-cves.py
+++ b/show-fixed-kernel-cves.py
@@ -41,8 +41,8 @@ def print_fixed_linux_cves(from_version_str, to_version_str):
   for stream, releases in streams.items():
     for release, cves in releases.items():
       if release != "outstanding" and from_version < version.Version(release) <= to_version:
-        cvelist += cves.items()
-  for cve, _ in sorted(cvelist):
+        cvelist += cves.keys()
+  for cve in sorted(cvelist):
     links += [f"[{cve}](https://nvd.nist.gov/vuln/detail/{cve})"]
   print(", ".join(links))
 


### PR DESCRIPTION
In some cases, when running `show-fixed-kernel-cves.py` with python 3.7+, it fails to run with the following errors:

```
Traceback (most recent call last):
  File ".../show-fixed-kernel-cves.py", line 68, in <module>
    print_fixed_linux_cves(options.from_version, options.to_version)
  File ".../show-fixed-kernel-cves.py",
line 55, in print_fixed_linux_cves
    for cve, _ in sorted(cvelist):
TypeError: '<' not supported between instances of 'dict' and 'dict'
```

To solve that, ignore values from the list.
