### PR TITLE
generate_payload: Create extension update payloads

### DIFF
--- a/download_payloads
+++ b/download_payloads
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -lt 1 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+  echo "Usage: $0 RELEASE_DESCRIPTORS..."
+  echo "Example: $0 alpha:1786.0.0 beta:1781.2.0"
+  echo "Downloads the release update payloads to ARCH-usr/VERSION/ folders."
+  echo "Expected to be run in .../sdk/src/scripts/data/"
+  echo "(usually before entering the chroot and running ./generate_payload data/ARCH-usr/VERSION/ keys/)."
+  exit 1
+fi
+
+if [ "$(basename "${PWD}")" != "data" ] || [ "$(basename "$(readlink -f ..)")" != "scripts" ]; then
+  echo "Expected to be run in .../sdk/src/scripts/data/" >&2
+  exit 1
+fi
+
+# Same as in copy-to-origin.sh and set-symlink.sh
+for TUPLE_COL in "$@"; do
+  IFS=":" read -r -a TUPLE <<< "${TUPLE_COL}"
+  CHANNEL="${TUPLE[0]}"
+  VERSION="${TUPLE[1]}"
+  for ARCH in amd64 arm64; do
+    echo "Downloading ${CHANNEL} ${VERSION} ${ARCH}"
+    rm -rf "${ARCH}-usr/${VERSION}"
+    mkdir -p "${ARCH}-usr/${VERSION}" && cd "${ARCH}-usr/${VERSION}"
+    BASEURL="https://bincache.flatcar-linux.net/images/${ARCH}/${VERSION}/"
+    # Note: Don't replace this with 'mapfile -t array < <(curl)' or 'read -r -a array <<< "$(curl)"' because that has no error checking
+    EXTRA_PAYLOADS=($(curl -H 'Accept: application/json' -fsSL "${BASEURL}" | jq -r ".[].name" | { grep -P '^(oem|flatcar)-.*raw(.sig)?$' || true ; }))
+    wget "${BASEURL}"{flatcar_production_update.bin.bz2,flatcar_production_update.bin.bz2.sig,flatcar_production_image.vmlinuz,flatcar_production_image.vmlinuz.sig}
+    for EXTRA_PAYLOAD in "${EXTRA_PAYLOADS[@]}"; do
+      wget "${BASEURL}${EXTRA_PAYLOAD}"
+    done
+    cd ../..
+  done
+done
+echo "Success"

--- a/generate_payload
+++ b/generate_payload
@@ -361,19 +361,41 @@ mkdir -p "${GNUPGHOME}"
 chmod 700 "${GNUPGHOME}"
 trap 'rm -rf ${GNUPGHOME}' EXIT
 
-OUTPUT_PATH="${DATA_DIR}/flatcar_production_update.gz"
-
 # Setup GnuPG for verifying the image signature
 gpg --batch --quiet --import <<< "${GPG_KEY}"
 
 echo "Verifying files"
-gpg --verify "${DATA_DIR}/flatcar_production_update.bin.bz2.sig"
-gpg --verify "${DATA_DIR}/flatcar_production_image.vmlinuz.sig"
+# Check that we have a signature for the files we work on
+test -f "${DATA_DIR}/flatcar_production_update.bin.bz2.sig"
+test -f "${DATA_DIR}/flatcar_production_image.vmlinuz.sig"
+for FILE_PATH in "${DATA_DIR}"/*.sig; do
+  gpg --verify "${FILE_PATH}"
+done
+
+echo "Generating extension payloads"
+for EXTENSION_PATH in "${DATA_DIR}"/*.raw; do
+  # Check that we have a signature for the files we work on
+  test -f "${EXTENSION_PATH}".sig
+  OUTPUT_PATH="${EXTENSION_PATH/.raw/.gz}"
+  if [ ! -f "${OUTPUT_PATH}" ]; then
+    echo "Generating ${OUTPUT_PATH}"
+    ./core_sign_update \
+      --image "${EXTENSION_PATH}" \
+      --output "${OUTPUT_PATH}" \
+      --private_keys "${PUBLIC_KEYS_DIR}/dummy.key.pem+pkcs11:object=10;type=private" \
+      --public_keys "${PUBLIC_KEYS_DIR}/dummy.pub.pem+${PUBLIC_KEYS_DIR}/flatcar.pub.pem" \
+      --keys_separator "+"
+  else
+    echo "ERROR: Found update payload already: ${OUTPUT_PATH}."
+    exit 1
+  fi
+done
 
 echo "Extracting flatcar_production_update.bin.bz2"
 bunzip2 -f -k "${DATA_DIR}/flatcar_production_update.bin.bz2"
 
-echo "Generating update payload"
+echo "Generating generic update payload"
+OUTPUT_PATH="${DATA_DIR}/flatcar_production_update.gz"
 if [ ! -f "${OUTPUT_PATH}" ]; then
     echo "Update payload not found. Building..."
     ./core_sign_update \


### PR DESCRIPTION
- download_payloads: Add helper script for update payload fetching
    
    The update payload fetching was a simple wget invocation until now but
    with OEM payloads and other future Flatcar extensions this gets more
    complicated.
    Add a script that finds out which extension payloads are available based
    on the Caddy JSON output.
- generate_payload: Create extension update payloads
    
    When a release has extension update payloads for OEM software these
    should be signed as well.
    Extend the generate_payload script to detect additional extension files
    and generate signed payloads for them.

## How to use

```
cd /run/media/usb/sdk/src/scripts/data/
~/flatcar/flatcar-build-scripts/download_payloads alpha:1786.0.0 beta:1781.2.0
# continue inside as usual with ./generate_payload data/$ARCH/$VERSION keys/
```

## Testing done

The above and
```
PROTOPATH=src/update_engine/ ./decode_payload ~/flatcar/scripts/sdk_container/src/third_party/coreos-overlay/coreos-base/coreos-au-key/files/official-v2.pub.pem /run/media/usb/sdk/src/scripts/data/test/3717.0.0/oem-qemu.gz /var/tmp/out
```
which was able to verify the signature.