### PR TITLE
show-changes: Fix excessive quoting

### DIFF
--- a/show-changes
+++ b/show-changes
@@ -12,9 +12,9 @@ if [ $# -lt 1 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
   exit 1
 fi
 
-: "${SCRIPTS_REPO:='scripts'}"
-: "${COREOS_OVERLAY_REPO:='coreos-overlay'}"
-: "${PORTAGE_STABLE_REPO:='portage-stable'}"
+: "${SCRIPTS_REPO:=scripts}"
+: "${COREOS_OVERLAY_REPO:=coreos-overlay}"
+: "${PORTAGE_STABLE_REPO:=portage-stable}"
 
 OLD="$1"
 NEW="${2-HEAD}"


### PR DESCRIPTION
Single quotes inside a line like below are treated as a part of the value:

: "${foo:='bar'}"

If foo is empty or unset then it will be set to "'bar'", instead of just "bar". This resulted in the script complaining that git can't operate on directory "'scripts'".
