### PR TITLE
tag-release: Port to new tagging function

### DIFF
--- a/tag-release
+++ b/tag-release
@@ -92,7 +92,7 @@ for REPO in ${REPOS}; do
         update_submodules "${OVERLAY_REF}" "${PORTAGE_REF}"
       fi
       create_versionfile "${SDK_VERSION}" "${VERSION}"
-      SIGN=1 update_and_push_version "${TAG}" true
+      SIGN=1 update_and_push_version "${TAG}" "$MAINT-$MAJOR"
     )
   else
     # Tag the other repos


### PR DESCRIPTION
The tagging function was changed in the scripts repo with https://github.com/flatcar/scripts/pull/799 (not on all branches but this is solved now) and since the tag-release script uses it we also have to adjust the function call here.

## How to use

Retag Alpha

## Testing done

None