### PR TITLE
Exclude profiles/repo_name when syncing with Gentoo

### DIFF
--- a/sync-with-gentoo
+++ b/sync-with-gentoo
@@ -34,7 +34,7 @@ GLOBAL_gentoo_repo="${GENTOO_REPO:-../gentoo}"
 GLOBAL_amend_mode=''
 
 while true; do
-    case "${1}" in
+    case "${1-}" in
         '--help'|'-h')
             echo "${0} [OPTIONS] CATEGORY[/PACKAGE_NAME] [CATEGORY[/PACKAGE_NAME] […]]"
             echo 'OPTIONS:'

--- a/sync-with-gentoo
+++ b/sync-with-gentoo
@@ -105,21 +105,18 @@ sync_git_prepare() {
     local path="${1}"
     local sync=''
     local gentoo_path="${GLOBAL_gentoo_repo}/${path}"
+    local rsync_opts=()
 
     if [[ ! -e "${gentoo_path}" ]]; then
         GLOBAL_obsolete_packages+=("${path}")
         return 0
     fi
 
-    if [[ -d "${path}" ]]; then
-        git rm -r --force --quiet "${path}"
-        sync='x'
-    elif [[ -e "${path}" ]]; then
-        git rm --force --quiet "${path}"
+    if [[ -e "${path}" ]]; then
         sync='x'
     fi
     mkdir --parents "$(dirname ${path})"
-    cp --archive "${gentoo_path}" "$(dirname ${path})"
+    rsync --archive --delete-before "${rsync_opts[@]}" "${gentoo_path}" "$(dirname ${path})"
     git add "${path}"
     if [[ -n "${sync}" ]]; then
         return 1

--- a/sync-with-gentoo
+++ b/sync-with-gentoo
@@ -112,6 +112,10 @@ sync_git_prepare() {
         return 0
     fi
 
+    case "${path}" in
+        profiles) rsync_opts+=( --exclude /profiles/repo_name )
+    esac
+
     if [[ -e "${path}" ]]; then
         sync='x'
     fi


### PR DESCRIPTION
# Exclude profiles/repo_name when syncing with Gentoo

We want to call our own repo portage-stable (or soon gentoo-subset) so stop setting this file back to "gentoo". It wasn't an issue before because we set the name to portage-stable in layout.conf, but you're not supposed to set it there anymore.

The change achieves this with rsync, which also gives the benefit of less disk churn.

I did consider doing this exclusion via portage-stable-packages-list, but one line is passed to sync-with-gentoo at a time, which doesn't really allow for exclusions. sync-with-gentoo already has specific rules for certain directories, so this doesn't seem so bad.

## How to use

Try it as usual and see whether repo_name changes.

## Testing done

I have manually run sync-with-gentoo locally to see the effect on repo_name and other files.