### PR TITLE
show-fixed-kernel-cve: use Python interpreter

### DIFF
--- a/show-fixed-kernel-cves.py
+++ b/show-fixed-kernel-cves.py
@@ -104,4 +104,4 @@ if not options.to_version:
 
 cves = fixed_linux_cves(Version(options.from_version), Version(options.to_version))
 if len(cves) > 0:
-    print(f"- Linux ({cves})")
+    print(f"{cves}")


### PR DESCRIPTION
Without this it makes 'scripts' calls failing.


---

I noticed well after that this script is actually called from `show-changes` 