### PR TITLE
sync-with-gentoo: Add signoff to commits

### DIFF
--- a/sync-with-gentoo
+++ b/sync-with-gentoo
@@ -93,6 +93,7 @@ commit_and_show() {
     if [[ -n "$(git status --porcelain | grep -v '^ ')" ]]; then
         git commit \
             --quiet \
+            --signoff \
             "${@}" \
             "${GLOBAL_extra_git_commit_options[@]}"
         GIT_PAGER=cat git show --stat


### PR DESCRIPTION
Weekly updates github action in scripts is still using this script, so let's update it to include the DCO in the commits.
