### PR TITLE
spawn-az-vm: Update settings

### DIFF
--- a/spawn-az-vm
+++ b/spawn-az-vm
@@ -16,7 +16,7 @@ DELETE_VM=
 REPO="${REPO:-"flatcar/scripts"}"
 OFFER="${OFFER:-"flatcar-container-linux-free"}"
 CHANNEL="${CHANNEL:-alpha}"
-SIZE="${SIZE:-Standard_D32ds_v5}"
+SIZE="${SIZE:-Standard_D32ds_v6}"
 # Note use "-" instead ":-" to be able to explicitly clear it
 EXTRA=(${EXTRA-default})
 if [ "${EXTRA[*]}" = "default" ]; then
@@ -124,7 +124,7 @@ fi
 for BRANCH in "$@"; do
   DERIVED=$(echo "${BRANCH}-${RANDOM}" | sed 's#[/_ ]##g')
   echo "Derived name: ${DERIVED}"
-  CMD="sudo systemd-run --uid=core --gid=core --unit='${DERIVED}' --working-directory='/home/core/' sh -c 'git clone --branch \"${BRANCH}\" \"https://github.com/${REPO}\" \"${DERIVED}\" && cd \"${DERIVED}\" && ./run_sdk_container -n \"${DERIVED}\" sh -c \" time ./build_packages && ./build_image && ./image_to_vm.sh --image_compression_formats=none \" '"
+  CMD="sudo systemd-run --uid=core --gid=core --unit='${DERIVED}' --working-directory='/home/core/' sh -c 'git clone --branch \"${BRANCH}\" \"https://github.com/${REPO}\" \"${DERIVED}\" && cd \"${DERIVED}\" && ./run_sdk_container -n \"${DERIVED}\" sh -c \" time ./build_packages && ./build_image prod sysext && ./image_to_vm.sh --image_compression_formats=none \" '"
   # Alternative but quoting issues: az vm extension set --resource-group "${RESOURCE}" --vm-name "${NAME}" --name customScript --publisher Microsoft.Azure.Extensions --settings "{\"commandToExecute\": \"${CMD}\"}"
   az vm run-command invoke --command-id RunShellScript --resource-group "${RESOURCE}" --name "${NAME}" --scripts "${CMD}"
   echo "Monitor the build:"


### PR DESCRIPTION
The image build didn't include the sysext images and we can also use v6 VMs now on Azure.

## How to use


## Testing done
