### PR TITLE
Check curl for bad HTTP status codes and escape backslashes

### DIFF
--- a/package-diff
+++ b/package-diff
@@ -70,8 +70,8 @@ function download {
         URL_B="https://bucket.release.flatcar-linux.net/flatcar-jenkins${MODE_B}${CHANNEL_B}/boards/${BOARD_B}/${VERSION_B}/${file}"
     fi
 
-    curl --location --silent -S -o "$A" "$URL_A"
-    curl --location --silent -S -o "$B" "$URL_B"
+    curl --fail --location --silent -S -o "$A" "$URL_A" || return 1
+    curl --fail --location --silent -S -o "$B" "$URL_B" || return 1
 
     if [[ ! -s "${A}" ]] || [[ ! -s "${B}" ]]; then
         return 1

--- a/size-change-report.sh
+++ b/size-change-report.sh
@@ -159,7 +159,7 @@ function handle_spec {
             kind="${spec_ar[4]}"
             url="https://${channel}.release.flatcar-linux.net/${board}/${version}"
             file=$(file_from_kind "${spec}" "${kind}")
-            curl --location --silent -S -o "${output}" "${url}/${file}"
+            curl --fail --location --silent -S -o "${output}" "${url}/${file}"
             echo "${kind}" >"${output_kind}"
             ;;
         bincache)
@@ -172,7 +172,7 @@ function handle_spec {
             kind="${spec_ar[3]}"
             url="https://bincache.flatcar-linux.net/images/${arch}/${version}"
             file=$(file_from_kind "${spec}" "${kind}")
-            curl --location --silent -S -o "${output}" "${url}/${file}"
+            curl --fail --location --silent -S -o "${output}" "${url}/${file}"
             echo "${kind}" >"${output_kind}"
             ;;
         local)

--- a/size-change-report.sh
+++ b/size-change-report.sh
@@ -459,7 +459,8 @@ function munge_path_into_regexp {
     local path="${1}"; shift
     local regexp="${path}"
 
-    # escape special stuff, means . * $ ^ [
+    # escape special stuff, means \ . * $ ^ [
+    regexp="${regexp//\\/\\\\}"
     regexp="${regexp//./\\.}"
     regexp="${regexp//\*/\\\*}"
     regexp="${regexp//^/\\^}"


### PR DESCRIPTION
The image changes report was emitting HTML and warnings about stray backslashes caused by systemd unit files with `\x2d` (dash) in the name.

`\x2d` still gets changed to `\x0d` for matching, but I didn't feel like this was worth fixing in the end. It still works as intended.